### PR TITLE
Add Lucas–Lehmer primality test

### DIFF
--- a/mttools/number_theory_tools/Primes.py
+++ b/mttools/number_theory_tools/Primes.py
@@ -161,3 +161,30 @@ def largest_prime_less_than(num: int) -> Optional[int]:
             return i
     else:
         return None
+
+
+def lucas_lehmer_primality_test(num: int) -> bool:
+    """
+    Uses Lucas–Lehmer primality test to test for primality of Mersenne numbers.
+
+    params:
+        num: Mersenne number to test primality of
+
+    return:
+        True if num is prime, False if it is not
+    """
+    if num < 7:
+        if num == 1:
+            return False
+        if num == 3:
+            return True
+        raise ValueError("num must be a mersenne number")
+
+    p = num.bit_length()
+    if 2 ** p - 1 != num:
+        raise ValueError("num must be a mersenne number")
+
+    s = 4
+    for _ in range(p - 2):
+        s = ((s * s) - 2) % num
+    return s == 0

--- a/tests/test_number_theory_tools/test_PrimeTools.py
+++ b/tests/test_number_theory_tools/test_PrimeTools.py
@@ -1,9 +1,12 @@
+import pytest
+
 from mttools.number_theory_tools.Primes import (
     division_primality_test,
     fermat_primality_test,
     largest_prime_less_than,
     prime_factors,
     sieve_of_eratosthenes,
+    lucas_lehmer_primality_test,
 )
 
 
@@ -65,3 +68,15 @@ class TestLargestPrimeLessThan:
 
     def test_primes_less_than_large_num(self):
         assert 105023 == largest_prime_less_than(105030)
+
+
+class TestLucasLehmerPrimalityTest:
+    def test_requires_mersenne_number(self):
+        with pytest.raises(ValueError):
+            lucas_lehmer_primality_test(25)
+
+    def test_with_prime(self):
+        assert lucas_lehmer_primality_test(2 ** 31 - 1)
+
+    def test_with_composite(self):
+        assert not lucas_lehmer_primality_test(2 ** 30 - 1)


### PR DESCRIPTION
Addresses Issue #12.

New function `lucas_lehmer_primality_test` in `mttools/number_theory_tools/Primes.py`, which implements the [Lucas–Lehmer primality test](https://en.wikipedia.org/wiki/Lucas%E2%80%93Lehmer_primality_test). Raises `ValueError` if the input is not a Mersenne number.