### PR TITLE
Added properties of bodies and fixed an error in "area_of_circle"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,8 @@ celerybeat.pid
 .env
 .venv
 
+# Github workflow
+.github
+
 # Mypy
 .mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # VSCode stuff
 settings.json
 launch.json
+.vscode
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -111,8 +111,5 @@ celerybeat.pid
 .env
 .venv
 
-# Github workflow
-.github
-
 # Mypy
 .mypy_cache/

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -77,7 +77,7 @@ class TestAreaOfCircle:
 ```
 
 The first test checks the correctness of one particular input.
-whereas the second tests a property for several differnt inputs.
+whereas the second tests a property for several different inputs.
 In this case the property revolves around r^2 == (-r)^2.
 
 Then, run `git status`

--- a/mttools/geometry_tools/PropertiesOfBodies.py
+++ b/mttools/geometry_tools/PropertiesOfBodies.py
@@ -9,7 +9,7 @@ def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
         Ixx is strong axis and Iyy is weak axis.
 
     >>> bar(3, 0.5)
-    {'Centroid': (1.5, 0.25), 'Area': 1.5, 'Ixx': 1.125, 'Iyy': 0.03125, 'Sx': 0.75, 'Sy': 0.125}
+    {'Centroid': (0.25, 1.5), 'Area': 1.5, 'Ixx': 1.125, 'Iyy': 0.03125, 'Sx': 0.75, 'Sy': 0.125}
 
     """
     if any((depth <= 0, thickness <= 0)):
@@ -21,7 +21,7 @@ def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
     Ixx = depth ** 3 * thickness / 12
     Iyy = thickness ** 3 * depth / 12
     return {
-        "Centroid": (y, x),
+        "Centroid": (x, y),
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -81,7 +81,7 @@ def Tbeam(
         depth is the total depth of the web (stem) and flange
 
     >>> tbeam(4, 0.5, 4, 0.5)
-    {'Centroid': (2.8166666666666664, 2.0), 'Area': 3.75,
+    {'Centroid': (2.0, 2.8166666666666664), 'Area': 3.75,
      'Ixx': 5.5614583333333325, 'Iyy': 2.703125,
      'Sx': 1.9744822485207099, 'Sy': 1.3515625}
     """
@@ -111,7 +111,7 @@ def Tbeam(
         web_thickness ** 3 * web_height / 12 + flange_width ** 3 * flange_thickness / 12
     )
     return {
-        "Centroid": (y, x),
+        "Centroid": (x, y),
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -136,7 +136,7 @@ def Ibeam_equal_flange(
         depth is the total depth of the web (stem) and flange
 
     >>> Ibeam_equalflange(8, 0.5, 6, 0.75)
-    {'Centroid': (4.0, 3.0), 'Area': 12.25,
+    {'Centroid': (3.0, 4.0), 'Area': 12.25,
      'Ixx': 130.13020833333334, 'Iyy': 27.067708333333332,
      'Sx': 32.532552083333336, 'Sy': 9.022569444444445}
     """
@@ -155,7 +155,7 @@ def Ibeam_equal_flange(
         + web_thickness ** 3 * web_height / 12
     )
     return {
-        "Centroid": (y, x),
+        "Centroid": (x, y),
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -182,7 +182,7 @@ def Ibeam_unequal_flange(
         depth is the total depth of the web (stem) and flange
 
     >>> Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1)
-    {'Centroid': (4.243110236220472, 4.5), 'Area': 15.875,
+    {'Centroid': (4.5, 4.243110236220472), 'Area': 15.875,
     'Ixx': 172.29872559875326, 'Iyy': 63.627604166666664,
     'Sx': 40.60670498917498, 'Sy': 14.139467592592592}
     """
@@ -227,7 +227,7 @@ def Ibeam_unequal_flange(
         + web_thickness ** 3 * web_height / 12
     )
     return {
-        "Centroid": (y, x),
+        "Centroid": (x, y1),
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,

--- a/mttools/geometry_tools/PropertiesOfBodies.py
+++ b/mttools/geometry_tools/PropertiesOfBodies.py
@@ -1,4 +1,6 @@
 from math import pi
+from typing import Tuple
+
 from mttools.utils.types import RealNumber
 
 
@@ -167,10 +169,8 @@ def Ibeam_equal_flange(
 def Ibeam_unequal_flange(
     depth: RealNumber,
     web_thickness: RealNumber,
-    top_flange_width: RealNumber,
-    top_flange_thickness: RealNumber,
-    btm_flange_width: RealNumber,
-    btm_flange_thickness: RealNumber,
+    top_flange: Tuple[RealNumber],
+    btm_flange: Tuple[RealNumber],
 ) -> dict:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of an I beam.
@@ -181,11 +181,15 @@ def Ibeam_unequal_flange(
 
         depth is the total depth of the web (stem) and flange
 
+        top flange / btm flange inputs are (width, thickness)
+
     >>> Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1)
     {'Centroid': (4.5, 4.243110236220472), 'Area': 15.875,
     'Ixx': 172.29872559875326, 'Iyy': 63.627604166666664,
     'Sx': 40.60670498917498, 'Sy': 14.139467592592592}
     """
+    top_flange_width, top_flange_thickness = top_flange
+    btm_flange_width, btm_flange_thickness = btm_flange
     if any(
         (
             depth <= 0,

--- a/mttools/geometry_tools/PropertiesOfBodies.py
+++ b/mttools/geometry_tools/PropertiesOfBodies.py
@@ -1,17 +1,18 @@
 from math import pi
-from typing import Tuple
+from typing import Tuple, Dict
 
 from mttools.utils.types import RealNumber
 
 
-def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
+def rect_bar(depth: RealNumber, thickness: RealNumber) -> Dict[str, float]:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a rectangular bar.
         The assumed orientation is with the depth along the y axis so that
         Ixx is strong axis and Iyy is weak axis.
 
-    >>> bar(3, 0.5)
-    {'Centroid': (0.25, 1.5), 'Area': 1.5, 'Ixx': 1.125, 'Iyy': 0.03125, 'Sx': 0.75, 'Sy': 0.125}
+    >>> rect_bar(3, 0.5)
+    {'Centroid X': 0.25, 'Centroid Y': 1.5, 'Area': 1.5,
+     'Ixx': 1.125, 'Iyy': 0.03125, 'Sx': 0.75, 'Sy': 0.125}
 
     """
     if any((depth <= 0, thickness <= 0)):
@@ -23,7 +24,8 @@ def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
     Ixx = depth ** 3 * thickness / 12
     Iyy = thickness ** 3 * depth / 12
     return {
-        "Centroid": (x, y),
+        "Centroid X": x,
+        "Centroid Y": y,
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -32,7 +34,9 @@ def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
     }
 
 
-def round_bar(outside_diameter: RealNumber, inside_diameter: RealNumber = None) -> dict:
+def round_bar(
+    outside_diameter: RealNumber, inside_diameter: RealNumber = None
+) -> Dict[str, float]:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a round bar.
         The assumed orientation is with the depth along the y axis so that
@@ -72,7 +76,7 @@ def Tbeam(
     web_thickness: RealNumber,
     flange_width: RealNumber,
     flange_thickness: RealNumber,
-) -> dict:
+) -> Dict[str, float]:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a T beam.
         The assumed orientation is with the depth along the y axis and the flange on top
@@ -82,8 +86,8 @@ def Tbeam(
 
         depth is the total depth of the web (stem) and flange
 
-    >>> tbeam(4, 0.5, 4, 0.5)
-    {'Centroid': (2.0, 2.8166666666666664), 'Area': 3.75,
+    >>> Tbeam(4, 0.5, 4, 0.5)
+    {'Centroid X': 2.0, 'Centroid Y': 2.8166666666666664, 'Area': 3.75,
      'Ixx': 5.5614583333333325, 'Iyy': 2.703125,
      'Sx': 1.9744822485207099, 'Sy': 1.3515625}
     """
@@ -113,7 +117,8 @@ def Tbeam(
         web_thickness ** 3 * web_height / 12 + flange_width ** 3 * flange_thickness / 12
     )
     return {
-        "Centroid": (x, y),
+        "Centroid X": x,
+        "Centroid Y": y,
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -127,7 +132,7 @@ def Ibeam_equal_flange(
     web_thickness: RealNumber,
     flange_width: RealNumber,
     flange_thickness: RealNumber,
-) -> dict:
+) -> Dict[str, float]:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of an I beam.
         The assumed orientation is with the depth along the y axis so that
@@ -137,8 +142,8 @@ def Ibeam_equal_flange(
 
         depth is the total depth of the web (stem) and flange
 
-    >>> Ibeam_equalflange(8, 0.5, 6, 0.75)
-    {'Centroid': (3.0, 4.0), 'Area': 12.25,
+    >>> Ibeam_equal_flange(8, 0.5, 6, 0.75)
+    {'Centroid X': 3.0, 'Centroid Y': 4.0, 'Area': 12.25,
      'Ixx': 130.13020833333334, 'Iyy': 27.067708333333332,
      'Sx': 32.532552083333336, 'Sy': 9.022569444444445}
     """
@@ -157,7 +162,8 @@ def Ibeam_equal_flange(
         + web_thickness ** 3 * web_height / 12
     )
     return {
-        "Centroid": (x, y),
+        "Centroid X": x,
+        "Centroid Y": y,
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,
@@ -169,9 +175,9 @@ def Ibeam_equal_flange(
 def Ibeam_unequal_flange(
     depth: RealNumber,
     web_thickness: RealNumber,
-    top_flange: Tuple[RealNumber],
-    btm_flange: Tuple[RealNumber],
-) -> dict:
+    top_flange: Tuple[RealNumber, RealNumber],
+    btm_flange: Tuple[RealNumber, RealNumber],
+) -> Dict[str, float]:
     """
     Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of an I beam.
         The assumed orientation is with the depth along the y axis so that
@@ -183,8 +189,8 @@ def Ibeam_unequal_flange(
 
         top flange / btm flange inputs are (width, thickness)
 
-    >>> Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1)
-    {'Centroid': (4.5, 4.243110236220472), 'Area': 15.875,
+    >>> Ibeam_unequal_flange(8, 0.5, (9, 0.75), (6, 1))
+    {'Centroid X': 4.5, 'Centroid Y': 4.243110236220472, 'Area': 15.875,
     'Ixx': 172.29872559875326, 'Iyy': 63.627604166666664,
     'Sx': 40.60670498917498, 'Sy': 14.139467592592592}
     """
@@ -231,7 +237,8 @@ def Ibeam_unequal_flange(
         + web_thickness ** 3 * web_height / 12
     )
     return {
-        "Centroid": (x, y1),
+        "Centroid X": x,
+        "Centroid Y": y1,
         "Area": area,
         "Ixx": Ixx,
         "Iyy": Iyy,

--- a/mttools/geometry_tools/PropertiesOfBodies.py
+++ b/mttools/geometry_tools/PropertiesOfBodies.py
@@ -1,0 +1,236 @@
+from math import pi
+from mttools.utils.types import RealNumber
+
+
+def rect_bar(depth: RealNumber, thickness: RealNumber) -> dict:
+    """
+    Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a rectangular bar.
+        The assumed orientation is with the depth along the y axis so that
+        Ixx is strong axis and Iyy is weak axis.
+
+    >>> bar(3, 0.5)
+    {'Centroid': (1.5, 0.25), 'Area': 1.5, 'Ixx': 1.125, 'Iyy': 0.03125, 'Sx': 0.75, 'Sy': 0.125}
+
+    """
+    if any((depth <= 0, thickness <= 0)):
+        raise ValueError("All dimensions must be greater than 0")
+
+    y = depth / 2
+    x = thickness / 2
+    area = depth * thickness
+    Ixx = depth ** 3 * thickness / 12
+    Iyy = thickness ** 3 * depth / 12
+    return {
+        "Centroid": (y, x),
+        "Area": area,
+        "Ixx": Ixx,
+        "Iyy": Iyy,
+        "Sx": Ixx / y,
+        "Sy": Iyy / x,
+    }
+
+
+def round_bar(outside_diameter: RealNumber, inside_diameter: RealNumber = None) -> dict:
+    """
+    Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a round bar.
+        The assumed orientation is with the depth along the y axis so that
+        Ixx is strong axis and Iyy is weak axis.
+
+    >>> round_bar(18, 15)
+    {'Centroid': 9.0, 'Area': 77.75441817634739,
+     'Ixx': 2667.9484736759196, 'Sxx': 296.4387192973244}
+
+    >>> round_bar(13, 0)
+    {'Centroid': 6.5, 'Area': 132.73228961416876,
+     'Ixx': 1401.9848090496575, 'Sxx': 215.68997062302424}
+
+    >>> round_bar(8)
+    {'Centroid': 4.0, 'Area': 50.26548245743669,
+     'Ixx': 201.06192982974676, 'Sxx': 50.26548245743669}
+    """
+    if not inside_diameter:
+        inside_diameter = 0
+
+    if any((outside_diameter <= 0, inside_diameter < 0)):
+        raise ValueError("All dimensions must be greater than 0")
+
+    y = outside_diameter / 2
+    area = pi * (outside_diameter ** 2 - inside_diameter ** 2) / 4
+    Ixx = pi * (outside_diameter ** 4 - inside_diameter ** 4) / 64
+    return {
+        "Centroid": y,
+        "Area": area,
+        "Ixx": Ixx,
+        "Sxx": Ixx / y,
+    }
+
+
+def Tbeam(
+    depth: RealNumber,
+    web_thickness: RealNumber,
+    flange_width: RealNumber,
+    flange_thickness: RealNumber,
+) -> dict:
+    """
+    Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of a T beam.
+        The assumed orientation is with the depth along the y axis and the flange on top
+        so that Ixx is strong axis and Iyy is weak axis.
+
+        The web is assumed to be centered on the flange.
+
+        depth is the total depth of the web (stem) and flange
+
+    >>> tbeam(4, 0.5, 4, 0.5)
+    {'Centroid': (2.8166666666666664, 2.0), 'Area': 3.75,
+     'Ixx': 5.5614583333333325, 'Iyy': 2.703125,
+     'Sx': 1.9744822485207099, 'Sy': 1.3515625}
+    """
+    if any((depth <= 0, web_thickness <= 0, flange_width <= 0, flange_thickness <= 0)):
+        raise ValueError("All dimensions must be greater than 0")
+
+    web_height = depth - web_thickness
+    y = depth - (
+        (
+            depth ** 2 * web_thickness
+            + flange_thickness ** 2 * (flange_width - web_thickness)
+        )
+        / (2 * (flange_width * flange_thickness + web_height * web_thickness))
+    )
+    x = flange_width / 2
+    area = flange_width * flange_thickness + web_height * web_thickness
+    Ixx = (
+        1
+        / 3
+        * (
+            web_thickness * y ** 3
+            + flange_width * (depth - y) ** 3
+            - (flange_width - web_thickness) * (depth - y - flange_thickness) ** 3
+        )
+    )
+    Iyy = (
+        web_thickness ** 3 * web_height / 12 + flange_width ** 3 * flange_thickness / 12
+    )
+    return {
+        "Centroid": (y, x),
+        "Area": area,
+        "Ixx": Ixx,
+        "Iyy": Iyy,
+        "Sx": Ixx / y,
+        "Sy": Iyy / x,
+    }
+
+
+def Ibeam_equal_flange(
+    depth: RealNumber,
+    web_thickness: RealNumber,
+    flange_width: RealNumber,
+    flange_thickness: RealNumber,
+) -> dict:
+    """
+    Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of an I beam.
+        The assumed orientation is with the depth along the y axis so that
+        Ixx is strong axis and Iyy is weak axis.
+
+        The web is assumed to be centered on the flanges.
+
+        depth is the total depth of the web (stem) and flange
+
+    >>> Ibeam_equalflange(8, 0.5, 6, 0.75)
+    {'Centroid': (4.0, 3.0), 'Area': 12.25,
+     'Ixx': 130.13020833333334, 'Iyy': 27.067708333333332,
+     'Sx': 32.532552083333336, 'Sy': 9.022569444444445}
+    """
+    if any((depth <= 0, web_thickness <= 0, flange_width <= 0, flange_thickness <= 0)):
+        raise ValueError("All dimensions must be greater than 0")
+
+    web_height = depth - 2 * flange_thickness
+    y = depth / 2
+    x = flange_width / 2
+    area = 2 * flange_width * flange_thickness + web_height * web_thickness
+    Ixx = (
+        flange_width * depth ** 3 - web_height ** 3 * (flange_width - web_thickness)
+    ) / 12
+    Iyy = (
+        2 * (flange_width ** 3 * flange_thickness / 12)
+        + web_thickness ** 3 * web_height / 12
+    )
+    return {
+        "Centroid": (y, x),
+        "Area": area,
+        "Ixx": Ixx,
+        "Iyy": Iyy,
+        "Sx": Ixx / y,
+        "Sy": Iyy / x,
+    }
+
+
+def Ibeam_unequal_flange(
+    depth: RealNumber,
+    web_thickness: RealNumber,
+    top_flange_width: RealNumber,
+    top_flange_thickness: RealNumber,
+    btm_flange_width: RealNumber,
+    btm_flange_thickness: RealNumber,
+) -> dict:
+    """
+    Calculates the Centroid, Area, Moment of Inetia, and Section Modulus  of an I beam.
+        The assumed orientation is with the depth along the y axis so that
+        Ixx is strong axis and Iyy is weak axis.
+
+        The web is assumed to be centered on the flanges.
+
+        depth is the total depth of the web (stem) and flange
+
+    >>> Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1)
+    {'Centroid': (4.243110236220472, 4.5), 'Area': 15.875,
+    'Ixx': 172.29872559875326, 'Iyy': 63.627604166666664,
+    'Sx': 40.60670498917498, 'Sy': 14.139467592592592}
+    """
+    if any(
+        (
+            depth <= 0,
+            web_thickness <= 0,
+            top_flange_width <= 0,
+            top_flange_thickness <= 0,
+            btm_flange_width <= 0,
+            btm_flange_thickness <= 0,
+        )
+    ):
+        raise ValueError("All dimensions must be greater than 0")
+
+    web_height = depth - top_flange_thickness - btm_flange_thickness
+    area = (
+        top_flange_width * top_flange_thickness
+        + web_height * web_thickness
+        + btm_flange_width * btm_flange_thickness
+    )
+    y1 = (
+        web_thickness * depth ** 2
+        + btm_flange_thickness ** 2 * (btm_flange_width - web_thickness)
+        + top_flange_thickness
+        * (top_flange_width - web_thickness)
+        * (2 * depth - top_flange_thickness)
+    ) / (2 * area)
+    y = max((y1, depth - y1))
+    x = max((top_flange_width, btm_flange_width)) / 2
+    Ixx = (
+        web_thickness * depth ** 3 / 3
+        + (btm_flange_width - web_thickness) * (btm_flange_thickness) ** 3 / 3
+        + (top_flange_width - web_thickness)
+        * (depth ** 3 - (depth - top_flange_thickness) ** 3)
+        / 3
+        - area * y1 ** 2
+    )
+    Iyy = (
+        top_flange_width ** 3 * top_flange_thickness / 12
+        + btm_flange_width ** 3 * btm_flange_thickness / 12
+        + web_thickness ** 3 * web_height / 12
+    )
+    return {
+        "Centroid": (y, x),
+        "Area": area,
+        "Ixx": Ixx,
+        "Iyy": Iyy,
+        "Sx": Ixx / y,
+        "Sy": Iyy / x,
+    }

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -51,5 +51,5 @@ def area_of_circle(radius: Number) -> Number:
     40.840704496667314
 
     """
-    radius = abs(radius)
+    radius = sqrt(radius.real * radius.real + radius.imag * radius.imag)
     return radius * radius * pi

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -5,15 +5,8 @@ A Collection of geometry realated function and tools.
 from math import sqrt, pi
 from typing import List
 
-from mttools.utils.types import Number, RealNumber
+from mttools.utils.types import Number
 from mttools.utils.exceptions import DimensionError
-from .PropertiesOfBodies import (
-    rect_bar,
-    round_bar,
-    Tbeam,
-    Ibeam_equal_flange,
-    Ibeam_unequal_flange,
-)
 
 
 def distance(start: List[Number], end: List[Number]) -> Number:

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -16,9 +16,6 @@ from .PropertiesOfBodies import (
 )
 
 
-__all__ = ["bar", "Tbeam", "Ibeam_equal_flange", "Ibeam_unequal_flange"]
-
-
 def distance(start: List[Number], end: List[Number]) -> Number:
     """
     Calculates the Euclidean distance between two points.
@@ -52,4 +49,5 @@ def area_of_circle(radius: Number) -> Number:
     7238.229473870883
 
     """
+    radius = abs(radius)
     return radius * radius * pi

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -47,6 +47,8 @@ def area_of_circle(radius: Number) -> Number:
     28.274333882308138
     >>> area_of_circle(-48)
     7238.229473870883
+    >>> area_of_circle(3+2j)
+    40.840704496667314
 
     """
     radius = abs(radius)

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -2,7 +2,7 @@
 A Collection of geometry realated function and tools.
 """
 
-from math import sqrt, pi, tan, atan, radians, degrees
+from math import sqrt, pi
 from typing import List
 
 from mttools.utils.types import Number, RealNumber

--- a/mttools/geometry_tools/__init__.py
+++ b/mttools/geometry_tools/__init__.py
@@ -2,10 +2,21 @@
 A Collection of geometry realated function and tools.
 """
 
-from math import sqrt, pi
+from math import sqrt, pi, tan, atan, radians, degrees
 from typing import List
 
-from mttools.utils.types import Number
+from mttools.utils.types import Number, RealNumber
+from mttools.utils.exceptions import DimensionError
+from .PropertiesOfBodies import (
+    rect_bar,
+    round_bar,
+    Tbeam,
+    Ibeam_equal_flange,
+    Ibeam_unequal_flange,
+)
+
+
+__all__ = ["bar", "Tbeam", "Ibeam_equal_flange", "Ibeam_unequal_flange"]
 
 
 def distance(start: List[Number], end: List[Number]) -> Number:

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -41,7 +41,7 @@ class TestAreaOfCircle:
 class TestRectBar:
     def test_rect_bar(self):
         assert rect_bar(3, 0.5) == {
-            "Centroid": (1.5, 0.25),
+            "Centroid": (0.25, 1.5),
             "Area": 1.5,
             "Ixx": 1.125,
             "Iyy": 0.03125,
@@ -91,7 +91,7 @@ class TestRoundBar:
 class TestTbeam:
     def test_Tbeam(self):
         assert Tbeam(4, 0.5, 4, 0.5) == {
-            "Centroid": (2.8166666666666664, 2.0),
+            "Centroid": (2.0, 2.8166666666666664),
             "Area": 3.75,
             "Ixx": 5.5614583333333325,
             "Iyy": 2.703125,
@@ -107,7 +107,7 @@ class TestTbeam:
 class TestIbeam_equal_flange:
     def test_Ibeam_equal_flange(self):
         assert Ibeam_equal_flange(8, 0.5, 6, 0.75) == {
-            "Centroid": (4.0, 3.0),
+            "Centroid": (3.0, 4.0),
             "Area": 12.25,
             "Ixx": 130.13020833333334,
             "Iyy": 27.067708333333332,
@@ -123,7 +123,7 @@ class TestIbeam_equal_flange:
 class TestIbeam_unequal_flange:
     def test_Ibeam_unequal_flange(self):
         assert Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1) == {
-            "Centroid": (4.243110236220472, 4.5),
+            "Centroid": (4.5, 4.243110236220472),
             "Area": 15.875,
             "Ixx": 172.29872559875326,
             "Iyy": 63.627604166666664,

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -33,6 +33,7 @@ class TestAreaOfCircle:
         assert area_of_circle(3) == 28.274333882308138
 
     @given(st.floats(allow_nan=False))
+    @given(st.complex_numbers(allow_nan=False))
     def test_inverse_radius_gives_same_area(self, radius):
         inverse_radius = radius * -1
         assert area_of_circle(radius) == area_of_circle(inverse_radius)

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -1,7 +1,16 @@
 from hypothesis import given
 import hypothesis.strategies as st
+from pytest import raises
 
-from mttools.geometry_tools import distance, area_of_circle
+from mttools.geometry_tools import (
+    distance,
+    area_of_circle,
+    rect_bar,
+    round_bar,
+    Tbeam,
+    Ibeam_equal_flange,
+    Ibeam_unequal_flange,
+)
 
 
 class TestDistance:
@@ -27,3 +36,101 @@ class TestAreaOfCircle:
     def test_inverse_radius_gives_same_area(self, radius):
         inverse_radius = radius * -1
         assert area_of_circle(radius) == area_of_circle(inverse_radius)
+
+
+class TestRectBar:
+    def test_rect_bar(self):
+        assert rect_bar(3, 0.5) == {
+            "Centroid": (1.5, 0.25),
+            "Area": 1.5,
+            "Ixx": 1.125,
+            "Iyy": 0.03125,
+            "Sx": 0.75,
+            "Sy": 0.125,
+        }
+
+    def test_zero_rect_bar(self):
+        with raises(ValueError):
+            rect_bar(1, 0)
+
+
+class TestRoundBar:
+    def test_hollow_bar(self):
+        assert round_bar(18, 15) == {
+            "Centroid": 9.0,
+            "Area": 77.75441817634739,
+            "Ixx": 2667.9484736759196,
+            "Sxx": 296.4387192973244,
+        }
+
+    def test_solid_bar_one(self):
+        assert round_bar(13, 0) == {
+            "Centroid": 6.5,
+            "Area": 132.73228961416876,
+            "Ixx": 1401.9848090496575,
+            "Sxx": 215.68997062302424,
+        }
+
+    def test_solid_bar_two(self):
+        assert round_bar(8) == {
+            "Centroid": 4.0,
+            "Area": 50.26548245743669,
+            "Ixx": 201.06192982974676,
+            "Sxx": 50.26548245743669,
+        }
+
+    def test_no_outside(self):
+        with raises(ValueError):
+            round_bar(-3)
+
+    def test_negative_inside(self):
+        with raises(ValueError):
+            round_bar(5, -2)
+
+
+class TestTbeam:
+    def test_Tbeam(self):
+        assert Tbeam(4, 0.5, 4, 0.5) == {
+            "Centroid": (2.8166666666666664, 2.0),
+            "Area": 3.75,
+            "Ixx": 5.5614583333333325,
+            "Iyy": 2.703125,
+            "Sx": 1.9744822485207099,
+            "Sy": 1.3515625,
+        }
+
+    def test_zero_Tbeam(self):
+        with raises(ValueError):
+            Tbeam(4, 0.5, 10, -1)
+
+
+class TestIbeam_equal_flange:
+    def test_Ibeam_equal_flange(self):
+        assert Ibeam_equal_flange(8, 0.5, 6, 0.75) == {
+            "Centroid": (4.0, 3.0),
+            "Area": 12.25,
+            "Ixx": 130.13020833333334,
+            "Iyy": 27.067708333333332,
+            "Sx": 32.532552083333336,
+            "Sy": 9.022569444444445,
+        }
+
+    def test_zero_Ibeam_equal_flange(self):
+        with raises(ValueError):
+            Ibeam_equal_flange(-1, 1, 3, 0.25)
+
+
+class TestIbeam_unequal_flange:
+    def test_Ibeam_unequal_flange(self):
+        assert Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1) == {
+            "Centroid": (4.243110236220472, 4.5),
+            "Area": 15.875,
+            "Ixx": 172.29872559875326,
+            "Iyy": 63.627604166666664,
+            "Sx": 40.60670498917498,
+            "Sy": 14.139467592592592,
+        }
+
+    def test_negative_Ibeam_unequal_flange(self):
+        with raises(ValueError):
+            Ibeam_unequal_flange(6, 2, 0, 0.5, -4, 1)

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -32,9 +32,13 @@ class TestAreaOfCircle:
     def test_interger_radius(self):
         assert area_of_circle(3) == 28.274333882308138
 
-    @given(st.floats(allow_nan=False))
-    @given(st.complex_numbers(allow_nan=False))
+    @given(st.floats(allow_nan=False, allow_infinity=False))
     def test_inverse_radius_gives_same_area(self, radius):
+        inverse_radius = radius * -1
+        assert area_of_circle(radius) == area_of_circle(inverse_radius)
+
+    @given(st.complex_numbers(allow_nan=False, allow_infinity=False))
+    def test_inverse_complex_radius(self, radius):
         inverse_radius = radius * -1
         assert area_of_circle(radius) == area_of_circle(inverse_radius)
 

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -127,7 +127,7 @@ class TestIbeam_equal_flange:
 
 class TestIbeam_unequal_flange:
     def test_Ibeam_unequal_flange(self):
-        assert Ibeam_unequal_flange(8, 0.5, 9, 0.75, 6, 1) == {
+        assert Ibeam_unequal_flange(8, 0.5, (9, 0.75), (6, 1)) == {
             "Centroid": (4.5, 4.243110236220472),
             "Area": 15.875,
             "Ixx": 172.29872559875326,
@@ -138,4 +138,4 @@ class TestIbeam_unequal_flange:
 
     def test_negative_Ibeam_unequal_flange(self):
         with raises(ValueError):
-            Ibeam_unequal_flange(6, 2, 0, 0.5, -4, 1)
+            Ibeam_unequal_flange(6, 2, (0, 0.5), (-4, 1))

--- a/tests/test_geometry_tools/test_GeometryTools.py
+++ b/tests/test_geometry_tools/test_GeometryTools.py
@@ -2,15 +2,7 @@ from hypothesis import given
 import hypothesis.strategies as st
 from pytest import raises
 
-from mttools.geometry_tools import (
-    distance,
-    area_of_circle,
-    rect_bar,
-    round_bar,
-    Tbeam,
-    Ibeam_equal_flange,
-    Ibeam_unequal_flange,
-)
+from mttools.geometry_tools import distance, area_of_circle
 
 
 class TestDistance:
@@ -41,101 +33,3 @@ class TestAreaOfCircle:
     def test_inverse_complex_radius(self, radius):
         inverse_radius = radius * -1
         assert area_of_circle(radius) == area_of_circle(inverse_radius)
-
-
-class TestRectBar:
-    def test_rect_bar(self):
-        assert rect_bar(3, 0.5) == {
-            "Centroid": (0.25, 1.5),
-            "Area": 1.5,
-            "Ixx": 1.125,
-            "Iyy": 0.03125,
-            "Sx": 0.75,
-            "Sy": 0.125,
-        }
-
-    def test_zero_rect_bar(self):
-        with raises(ValueError):
-            rect_bar(1, 0)
-
-
-class TestRoundBar:
-    def test_hollow_bar(self):
-        assert round_bar(18, 15) == {
-            "Centroid": 9.0,
-            "Area": 77.75441817634739,
-            "Ixx": 2667.9484736759196,
-            "Sxx": 296.4387192973244,
-        }
-
-    def test_solid_bar_one(self):
-        assert round_bar(13, 0) == {
-            "Centroid": 6.5,
-            "Area": 132.73228961416876,
-            "Ixx": 1401.9848090496575,
-            "Sxx": 215.68997062302424,
-        }
-
-    def test_solid_bar_two(self):
-        assert round_bar(8) == {
-            "Centroid": 4.0,
-            "Area": 50.26548245743669,
-            "Ixx": 201.06192982974676,
-            "Sxx": 50.26548245743669,
-        }
-
-    def test_no_outside(self):
-        with raises(ValueError):
-            round_bar(-3)
-
-    def test_negative_inside(self):
-        with raises(ValueError):
-            round_bar(5, -2)
-
-
-class TestTbeam:
-    def test_Tbeam(self):
-        assert Tbeam(4, 0.5, 4, 0.5) == {
-            "Centroid": (2.0, 2.8166666666666664),
-            "Area": 3.75,
-            "Ixx": 5.5614583333333325,
-            "Iyy": 2.703125,
-            "Sx": 1.9744822485207099,
-            "Sy": 1.3515625,
-        }
-
-    def test_zero_Tbeam(self):
-        with raises(ValueError):
-            Tbeam(4, 0.5, 10, -1)
-
-
-class TestIbeam_equal_flange:
-    def test_Ibeam_equal_flange(self):
-        assert Ibeam_equal_flange(8, 0.5, 6, 0.75) == {
-            "Centroid": (3.0, 4.0),
-            "Area": 12.25,
-            "Ixx": 130.13020833333334,
-            "Iyy": 27.067708333333332,
-            "Sx": 32.532552083333336,
-            "Sy": 9.022569444444445,
-        }
-
-    def test_zero_Ibeam_equal_flange(self):
-        with raises(ValueError):
-            Ibeam_equal_flange(-1, 1, 3, 0.25)
-
-
-class TestIbeam_unequal_flange:
-    def test_Ibeam_unequal_flange(self):
-        assert Ibeam_unequal_flange(8, 0.5, (9, 0.75), (6, 1)) == {
-            "Centroid": (4.5, 4.243110236220472),
-            "Area": 15.875,
-            "Ixx": 172.29872559875326,
-            "Iyy": 63.627604166666664,
-            "Sx": 40.60670498917498,
-            "Sy": 14.139467592592592,
-        }
-
-    def test_negative_Ibeam_unequal_flange(self):
-        with raises(ValueError):
-            Ibeam_unequal_flange(6, 2, (0, 0.5), (-4, 1))

--- a/tests/test_geometry_tools/test_PropertiesOfBodies.py
+++ b/tests/test_geometry_tools/test_PropertiesOfBodies.py
@@ -1,0 +1,112 @@
+from pytest import raises
+
+
+from mttools.geometry_tools.PropertiesOfBodies import (
+    rect_bar,
+    round_bar,
+    Tbeam,
+    Ibeam_equal_flange,
+    Ibeam_unequal_flange,
+)
+
+
+class TestRectBar:
+    def test_rect_bar(self):
+        assert rect_bar(3, 0.5) == {
+            "Centroid X": 0.25,
+            "Centroid Y": 1.5,
+            "Area": 1.5,
+            "Ixx": 1.125,
+            "Iyy": 0.03125,
+            "Sx": 0.75,
+            "Sy": 0.125,
+        }
+
+    def test_zero_rect_bar(self):
+        with raises(ValueError):
+            rect_bar(1, 0)
+
+
+class TestRoundBar:
+    def test_hollow_bar(self):
+        assert round_bar(18, 15) == {
+            "Centroid": 9.0,
+            "Area": 77.75441817634739,
+            "Ixx": 2667.9484736759196,
+            "Sxx": 296.4387192973244,
+        }
+
+    def test_solid_bar_one(self):
+        assert round_bar(13, 0) == {
+            "Centroid": 6.5,
+            "Area": 132.73228961416876,
+            "Ixx": 1401.9848090496575,
+            "Sxx": 215.68997062302424,
+        }
+
+    def test_solid_bar_two(self):
+        assert round_bar(8) == {
+            "Centroid": 4.0,
+            "Area": 50.26548245743669,
+            "Ixx": 201.06192982974676,
+            "Sxx": 50.26548245743669,
+        }
+
+    def test_no_outside(self):
+        with raises(ValueError):
+            round_bar(-3)
+
+    def test_negative_inside(self):
+        with raises(ValueError):
+            round_bar(5, -2)
+
+
+class TestTbeam:
+    def test_Tbeam(self):
+        assert Tbeam(4, 0.5, 4, 0.5) == {
+            "Centroid X": 2.0,
+            "Centroid Y": 2.8166666666666664,
+            "Area": 3.75,
+            "Ixx": 5.5614583333333325,
+            "Iyy": 2.703125,
+            "Sx": 1.9744822485207099,
+            "Sy": 1.3515625,
+        }
+
+    def test_zero_Tbeam(self):
+        with raises(ValueError):
+            Tbeam(4, 0.5, 10, -1)
+
+
+class TestIbeam_equal_flange:
+    def test_Ibeam_equal_flange(self):
+        assert Ibeam_equal_flange(8, 0.5, 6, 0.75) == {
+            "Centroid X": 3.0,
+            "Centroid Y": 4.0,
+            "Area": 12.25,
+            "Ixx": 130.13020833333334,
+            "Iyy": 27.067708333333332,
+            "Sx": 32.532552083333336,
+            "Sy": 9.022569444444445,
+        }
+
+    def test_zero_Ibeam_equal_flange(self):
+        with raises(ValueError):
+            Ibeam_equal_flange(-1, 1, 3, 0.25)
+
+
+class TestIbeam_unequal_flange:
+    def test_Ibeam_unequal_flange(self):
+        assert Ibeam_unequal_flange(8, 0.5, (9, 0.75), (6, 1)) == {
+            "Centroid X": 4.5,
+            "Centroid Y": 4.243110236220472,
+            "Area": 15.875,
+            "Ixx": 172.29872559875326,
+            "Iyy": 63.627604166666664,
+            "Sx": 40.60670498917498,
+            "Sy": 14.139467592592592,
+        }
+
+    def test_negative_Ibeam_unequal_flange(self):
+        with raises(ValueError):
+            Ibeam_unequal_flange(6, 2, (0, 0.5), (-4, 1))


### PR DESCRIPTION
I added a file to the geometry tools to calculate section modulus (and other properties) of bodies. These include rectangular bars, round bars, T sections, and I sections. 

Lastly I noticed that the area_of_circle function allowed for complex numbers but was not correctly calculating the area of a circle in the complex plane. The correct radius for a complex radius is the complex modulus of the radius (i.e. radius = a + bi = [a^2 + b^2]^(1/2)).